### PR TITLE
Close the request body source

### DIFF
--- a/src/main/java/com/convertapi/client/RequestBodyStream.java
+++ b/src/main/java/com/convertapi/client/RequestBodyStream.java
@@ -2,7 +2,6 @@ package com.convertapi.client;
 
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
-import okhttp3.internal.Util;
 import okio.BufferedSink;
 import okio.Okio;
 import okio.Source;
@@ -21,12 +20,8 @@ class RequestBodyStream {
 
             @Override
             public void writeTo(BufferedSink sink) throws IOException {
-                Source source = null;
-                try {
-                    source = Okio.source(inputStream);
+                try (Source source = Okio.source(inputStream)) {
                     sink.writeAll(source);
-                } finally {
-                    Util.closeQuietly(source);
                 }
             }
         };


### PR DESCRIPTION
Hi. We are researchers from Mahidol University, Thailand, and the State University of Ceará, Brazil, working on a research project for improving open-source projects by using the latest accepted answer from Stack Overflow that matched your code snippet. We found this recommendation for improving your code from https://stackoverflow.com/a/41251473.

Note: Our study is approved by the Institutional Review Board of Mahidol University. You can find the participant information sheet explaining this study https://drive.google.com/file/d/1ml5AqrtWQ9pnifTQyTFTcWQmwp6RuPA7/view?usp=sharing.

----

## Proposed change

Use try-with-resources for the Okio source so request streaming closes it even when copying fails.

<!-- Include the Testing section only when a relevant test exists and was run. Otherwise remove this comment and the entire section below. -->
## Testing

`mvn -q test`

Result: Passed
